### PR TITLE
Added TelemetryCommand that handles telemetry entries

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TelemetryCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TelemetryCommand.java
@@ -1,0 +1,108 @@
+package org.firstinspires.ftc.teamcode.commands;
+
+import org.firstinspires.ftc.teamcode.subsystems.Robot;
+import org.ftcvertex.vertices.Command;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class TelemetryCommand implements Command {
+    private final Robot robot = Robot.getInstance();
+
+    private final List<TelemetryEntry> entries = new ArrayList<>();
+    private boolean clearEachLoop = true;
+
+    private volatile boolean disabled = false;
+
+    public TelemetryCommand(){}
+
+    public TelemetryCommand addData(String caption, Supplier<?> supplier) {
+        entries.add(new DataEntry(caption,supplier));
+        return this;
+    }
+
+    public TelemetryCommand addLine(String line) {
+        entries.add(new LineEntry(line));
+        return this;
+    }
+
+    public TelemetryCommand clearEachLoop(boolean clear) {
+        this.clearEachLoop = clear;
+        return this;
+    }
+
+    @Override
+    public void init() {
+        robot.telemetry.clear();
+    }
+
+    @Override
+    public void loop() {
+        if(!disabled) {
+            if (clearEachLoop) {
+                clear();
+            }
+
+            for (TelemetryEntry entry : entries) {
+                entry.write(robot);
+            }
+
+            robot.telemetry.update();
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
+    }
+
+    public void toggleDisabled() {
+        setDisabled(!disabled);
+    }
+
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    public void clear(){
+        robot.telemetry.clear();
+    }
+
+    // Internal interface
+    private interface TelemetryEntry {
+        void write(Robot robot);
+    }
+
+    private static class DataEntry implements TelemetryEntry {
+        private final String caption;
+        private final Supplier<?> supplier;
+
+        DataEntry(String caption, Supplier<?> supplier) {
+            this.caption = caption;
+            this.supplier = supplier;
+        }
+
+        @Override
+        public void write(Robot robot) {
+            robot.telemetry.addData(caption, supplier::get);
+        }
+    }
+
+    private static class LineEntry implements TelemetryEntry {
+        private final String line;
+
+        LineEntry(String line) {
+            this.line = line;
+        }
+
+        @Override
+        public void write(Robot robot) {
+            robot.telemetry.addLine(line);
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TelemetryCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/TelemetryCommand.java
@@ -27,6 +27,17 @@ public class TelemetryCommand implements Command {
         return this;
     }
 
+    public TelemetryCommand addDisabledTag(boolean add) {
+        if (add) {
+            entries.add(new DataEntry("Disabled", this::isDisabled));
+        }
+        return this;
+    }
+
+    public TelemetryCommand addDisabledTag() {
+        return addDisabledTag(true);
+    }
+
     public TelemetryCommand clearEachLoop(boolean clear) {
         this.clearEachLoop = clear;
         return this;
@@ -73,9 +84,20 @@ public class TelemetryCommand implements Command {
         robot.telemetry.clear();
     }
 
+    public TelemetryCommand copy() {
+        TelemetryCommand copy = new TelemetryCommand();
+        for (TelemetryEntry entry : this.entries) {
+            copy.entries.add(entry.copy());
+        }
+        copy.clearEachLoop = this.clearEachLoop;
+        copy.disabled = this.disabled;
+        return copy;
+    }
+
     // Internal interface
     private interface TelemetryEntry {
         void write(Robot robot);
+        TelemetryEntry copy();
     }
 
     private static class DataEntry implements TelemetryEntry {
@@ -91,6 +113,11 @@ public class TelemetryCommand implements Command {
         public void write(Robot robot) {
             robot.telemetry.addData(caption, supplier::get);
         }
+
+        @Override
+        public TelemetryEntry copy() {
+            return new DataEntry(caption, supplier);
+        }
     }
 
     private static class LineEntry implements TelemetryEntry {
@@ -103,6 +130,11 @@ public class TelemetryCommand implements Command {
         @Override
         public void write(Robot robot) {
             robot.telemetry.addLine(line);
+        }
+
+        @Override
+        public TelemetryEntry copy() {
+            return new LineEntry(line);
         }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Auto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Auto.java
@@ -5,6 +5,7 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
 import org.firstinspires.ftc.teamcode.commands.MoveLift;
 import org.firstinspires.ftc.teamcode.commands.MoveScorer;
+import org.firstinspires.ftc.teamcode.commands.TelemetryCommand;
 import org.firstinspires.ftc.teamcode.subsystems.Lift;
 import org.firstinspires.ftc.teamcode.subsystems.Robot;
 import org.firstinspires.ftc.teamcode.subsystems.Scorer;
@@ -21,16 +22,25 @@ public class Auto extends LinearOpMode {
     public void runOpMode() throws InterruptedException {
         robot.init(this);
 
+        TelemetryCommand telemetryCommand = new TelemetryCommand()
+                .addLine("Running")
+                .addData("Lift", robot.lift::isFinished)
+                .clearEachLoop(true);
+        telemetryCommand.addData("Disabled", () -> telemetryCommand.isDisabled() ? "True" : "False");
+
         CommandRunner commandRunner = new CommandRunner(
-            new SeriesCommand(
-                new MoveLift(Lift.Targets.LOW),
-                new MoveScorer(Scorer.Targets.TRANSFER),
-                new SleepCommand(400),
                 new ParallelCommand(
-                    new MoveLift(Lift.Targets.HIGH),
-                    new MoveScorer(Scorer.Targets.SCORE)
+                        new SeriesCommand(
+                                new MoveLift(Lift.Targets.LOW),
+                                new MoveScorer(Scorer.Targets.TRANSFER),
+                                new SleepCommand(400),
+                                new ParallelCommand(
+                                        new MoveLift(Lift.Targets.HIGH),
+                                        new MoveScorer(Scorer.Targets.SCORE)
+                                )
+                        ),
+                        telemetryCommand
                 )
-            )
         );
 
         waitForStart();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Auto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Auto.java
@@ -9,6 +9,7 @@ import org.firstinspires.ftc.teamcode.commands.TelemetryCommand;
 import org.firstinspires.ftc.teamcode.subsystems.Lift;
 import org.firstinspires.ftc.teamcode.subsystems.Robot;
 import org.firstinspires.ftc.teamcode.subsystems.Scorer;
+import org.firstinspires.ftc.teamcode.subsystems.TelemetryProfiles;
 import org.ftcvertex.vertices.CommandRunner;
 import org.ftcvertex.vertices.ParallelCommand;
 import org.ftcvertex.vertices.SeriesCommand;
@@ -22,11 +23,8 @@ public class Auto extends LinearOpMode {
     public void runOpMode() throws InterruptedException {
         robot.init(this);
 
-        TelemetryCommand telemetryCommand = new TelemetryCommand()
-                .addLine("Running")
-                .addData("Lift", robot.lift::isFinished)
-                .clearEachLoop(true);
-        telemetryCommand.addData("Disabled", () -> telemetryCommand.isDisabled() ? "True" : "False");
+        TelemetryCommand telemetryCommand = TelemetryProfiles
+                .getProfile(TelemetryProfiles.Profile.DEFAULT);
 
         CommandRunner commandRunner = new CommandRunner(
                 new ParallelCommand(

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Tele.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Tele.java
@@ -6,6 +6,7 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import org.firstinspires.ftc.teamcode.commands.ButtonAction;
 import org.firstinspires.ftc.teamcode.commands.MoveLift;
 import org.firstinspires.ftc.teamcode.commands.MoveScorer;
+import org.firstinspires.ftc.teamcode.commands.TelemetryCommand;
 import org.firstinspires.ftc.teamcode.subsystems.Lift;
 import org.firstinspires.ftc.teamcode.subsystems.Robot;
 import org.firstinspires.ftc.teamcode.subsystems.Scorer;
@@ -20,30 +21,36 @@ public class Tele extends LinearOpMode {
     public void runOpMode() throws InterruptedException {
         robot.init(this);
 
-        CommandRunner commandRunner = new CommandRunner();
+        TelemetryCommand telemetryCommand = new TelemetryCommand()
+                .addLine("Running")
+                .addData("Lift Finished", robot.lift::isFinished)
+                .clearEachLoop(true);
+        telemetryCommand.addData("Disabled", telemetryCommand::isDisabled);
+
+        CommandRunner commandRunner = new CommandRunner(telemetryCommand);
 
         ButtonAction reset = new ButtonAction(
-            new SeriesCommand(
-                new MoveLift(Lift.Targets.GROUND),
-                new MoveScorer(Scorer.Targets.TRANSFER)
-            ),
-            commandRunner
+                new SeriesCommand(
+                        new MoveLift(Lift.Targets.GROUND),
+                        new MoveScorer(Scorer.Targets.TRANSFER)
+                ),
+                commandRunner
         );
 
         ButtonAction transfer = new ButtonAction(
-            new SeriesCommand(
-                new MoveLift(Lift.Targets.LOW),
-                new MoveScorer(Scorer.Targets.TRANSFER)
-            ),
-            commandRunner
+                new SeriesCommand(
+                        new MoveLift(Lift.Targets.LOW),
+                        new MoveScorer(Scorer.Targets.TRANSFER)
+                ),
+                commandRunner
         );
 
         ButtonAction score = new ButtonAction(
-            new SeriesCommand(
-              new MoveLift(Lift.Targets.HIGH),
-              new MoveScorer(Scorer.Targets.SCORE)
-            ),
-            commandRunner
+                new SeriesCommand(
+                        new MoveLift(Lift.Targets.HIGH),
+                        new MoveScorer(Scorer.Targets.SCORE)
+                ),
+                commandRunner
         );
 
         waitForStart();
@@ -54,6 +61,12 @@ public class Tele extends LinearOpMode {
             reset.update(robot.gamepad1.a);
             transfer.update(robot.gamepad1.b);
             score.update(robot.gamepad1.dpad_down);
+
+            if (robot.gamepad2.right_bumper) {
+                telemetryCommand.setDisabled(true);
+            }else if (robot.gamepad2.left_bumper) {
+                telemetryCommand.setDisabled(false);
+            }
 
             commandRunner.update();
             robot.update();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Tele.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Tele.java
@@ -10,6 +10,7 @@ import org.firstinspires.ftc.teamcode.commands.TelemetryCommand;
 import org.firstinspires.ftc.teamcode.subsystems.Lift;
 import org.firstinspires.ftc.teamcode.subsystems.Robot;
 import org.firstinspires.ftc.teamcode.subsystems.Scorer;
+import org.firstinspires.ftc.teamcode.subsystems.TelemetryProfiles;
 import org.ftcvertex.vertices.CommandRunner;
 import org.ftcvertex.vertices.SeriesCommand;
 
@@ -21,11 +22,8 @@ public class Tele extends LinearOpMode {
     public void runOpMode() throws InterruptedException {
         robot.init(this);
 
-        TelemetryCommand telemetryCommand = new TelemetryCommand()
-                .addLine("Running")
-                .addData("Lift Finished", robot.lift::isFinished)
-                .clearEachLoop(true);
-        telemetryCommand.addData("Disabled", telemetryCommand::isDisabled);
+        TelemetryCommand telemetryCommand = TelemetryProfiles
+                .getProfile(TelemetryProfiles.Profile.TELEOP);
 
         CommandRunner commandRunner = new CommandRunner(telemetryCommand);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Scorer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Scorer.java
@@ -27,4 +27,7 @@ public class Scorer {
     public void setPosition(double target) {
         scorer.setPosition(target);
     }
+    public double getPosition(){
+        return scorer.getPosition();
+    }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/TelemetryProfiles.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/TelemetryProfiles.java
@@ -1,0 +1,68 @@
+package org.firstinspires.ftc.teamcode.subsystems;
+
+import org.firstinspires.ftc.teamcode.commands.TelemetryCommand;
+
+import java.util.EnumMap;
+
+public final class TelemetryProfiles{
+    private final static Robot robot = Robot.getInstance();
+    private final static EnumMap<Profile, TelemetryCommand> profiles = new EnumMap<>(Profile.class);
+
+    public enum Profile{
+        DEFAULT, LIFT_ONLY, SCORER_ONLY, TELEOP // Add more as needed
+    }
+
+    //Prevent class from being instantiated
+    private TelemetryProfiles(){}
+
+    static {
+        profiles.put(Profile.DEFAULT, new TelemetryCommand()
+                .addLine("Running")
+                .addData("Lift Finished", robot.lift::isFinished)
+                .addData("Scorer Position", robot.scorer::getPosition)
+                .addDisabledTag(true)
+        );
+
+
+        profiles.put(Profile.LIFT_ONLY, new TelemetryCommand()
+                .addData("Lift Finished", robot.lift::isFinished)
+                .addDisabledTag(true)
+        );
+
+
+        profiles.put(Profile.SCORER_ONLY, new TelemetryCommand()
+                .addData("Scorer Position", robot.scorer::getPosition)
+                .addDisabledTag()
+                .clearEachLoop(false)
+        );
+
+
+        profiles.put(Profile.TELEOP, new TelemetryCommand()
+                .addLine("Running")
+                .addData("Lift Finished", robot.lift::isFinished)
+                .addData("Scorer Position", robot.scorer::getPosition)
+                .addData("Left Stick Y",() -> robot.gamepad1.left_stick_y)
+                .addData("Left Stick X",() -> robot.gamepad1.left_stick_x)
+                .addData("Right Stick X",() -> robot.gamepad1.right_stick_x)
+                .addData("Right Trigger",() -> robot.gamepad1.right_trigger)
+                .clearEachLoop(true)
+        );
+
+        //Add more profiles here
+    }
+
+
+    ///@return A copy of the TelemetryCommand with the given key
+    ///@param key The key of the TelemetryCommand profile to get
+    ///@throws IllegalArgumentException If the profile with the given key is not defined
+    public static TelemetryCommand getProfile(Profile key){
+        TelemetryCommand command = profiles.get(key);
+        if(command == null){
+            throw new IllegalArgumentException("Profile " + key + " is not defined.");
+        }
+
+        // Copy the command so any changes to the command by the calling opMode
+        // doesn't affect the original profile
+        return command.copy();
+    }
+}


### PR DESCRIPTION
# Pull Request: Add `TelemetryCommand` and Autonomous/TeleOp Examples

## Overview
This PR introduces a robust `TelemetryCommand` implementation designed to integrate with the Vertices command framework. It allows for dynamic, live-updating telemetry output with support for fluent configuration, conditional disabling, and runtime toggling. The example opmodes `Auto` and `Tele` were updated to show how TelemetryCommand is used.

---

## Key Additions

###  `TelemetryCommand`
- Implements `Command` interface to allow telemetry to run simultaneously with other commands.
- Supports:
  - `.addData(String, Supplier<?>)`
  - `.addLine(String)`
  - `.clearEachLoop(boolean)`
  - Runtime enable/disable via `setDisabled()`, `toggleDisabled()`, and `isDisabled()`
- Entries are encapsulated in internal interfaces (`TelemetryEntry`, `DataEntry`, `LineEntry`) for modularity.

###  `examples/Tele.java`
- Demonstrates TeleOp integration using `TelemetryCommand` and `ButtonAction`.
- Shows how to toggle telemetry output live using gamepad buttons.
- Runs telemetry continuously in parallel with other robot control commands.

### `examples/Auto.java`
- Demonstrates Autonomous mode using `SeriesCommand` and `ParallelCommand`.
- Runs a full lift + scorer sequence while telemetry is executed in parallel.

---

## Improvements
- Adds a reusable telemetry pattern that supports live data monitoring within the command framework.
- Keeps telemetry separated from robot control logic.
- Improves debugging and field feedback during both TeleOp and Auto.
