### PR TITLE
Added StoppableCommand for easy control over Commands while they are running

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,83 @@
 # Vertices
-A simple, easy-to-use command system.
-Read our slideshow on it [here](https://docs.google.com/presentation/d/1boNWFfqJhmMipA3C38eTGi0WhQw5I1PjR8GlLHR41hk/edit?usp=sharing)
+
+A simple, easy-to-use command system for FTC.
+
+[View our slideshow presentation](https://docs.google.com/presentation/d/1boNWFfqJhmMipA3C38eTGi0WhQw5I1PjR8GlLHR41hk/edit?usp=sharing)
+
+## Quick Start
+
+Commands are executed through `CommandRunner` instances. Every `Command` implements three methods:
+
+- `void init()` - Runs once when the command starts
+- `void loop()` - Runs continuously until finished
+- `boolean isFinished()` - Returns true when complete
+
+### Basic Structure
+
+Build complex behaviors by nesting commands:
+
+```java
+Command autonomous = new Command(
+    new SeriesCommand(
+        new ParallelCommand(
+            new MoveArm(Arm.Targets.HIGH),
+            new OpenClaw()
+        ),
+        new DriveForward(24)
+    )
+);
+```
+
+This runs `MoveArm` and `OpenClaw` simultaneously, then executes `DriveForward` after both complete. NOTE: These are examples, **NOT** built in `Command`s
+
+## Built-in Commands
+
+### Scheduling Commands
+- **`SeriesCommand`** - Runs commands one after another
+- **`ParallelCommand`** - Runs multiple commands simultaneously
+
+### Utility Commands
+- **`SleepCommand`** - Waits for a specified duration
+- **`AwaitCommand`** - Waits until a condition becomes true (with optional timeout)
+- **`CustomCommand`** - Executes a `Runnable` once (supports lambda expressions)
+
+### Control Commands
+- **`SwitchCommand`** - Executes different commands based on a condition
+- **`StoppableCommand`** - Wrapper that allows pausing/stopping commands during runtime
+  - `stop()` - Ends the command immediately
+  - `disable()` - Pauses execution (can be re-enabled)
+  - `enable()` - Resumes execution
+
+### Debug Commands
+- **`TelemetryCommand`** - Creates telemetry displays with method chaining
+  ```java
+  telemetryCommand
+      .addLine("Robot Status")
+      .addData("Position", () -> robot.getPosition())
+      .addDisabledTag();
+  ```
+
+## Required Subsystems
+
+### Robot
+Central container for all hardware and subsystems. Access via `Robot.getInstance()` - this class cannot be instantiated directly.
+
+### TelemetryProfiles
+Manages saved `TelemetryCommand` instances mapped to enums.
+- `getProfile(Profile profile)` - Returns a copy of the specified telemetry profile
+
+## Example Usage
+
+```java
+// Create a complex autonomous routine
+Command auto = new SeriesCommand(
+    new TelemetryCommand().addLine("Starting autonomous..."),
+    new ParallelCommand(
+        new MoveArm(Arm.Targets.PICKUP),
+        new DriveToPosition(startPosition)
+    ),
+    new AwaitCommand(() -> sensor.isPressed(), 5.0), // Wait max 5 seconds
+    new CustomCommand(() -> claw.close()),
+    new SleepCommand(1000) // Wait 1 second
+);
+```

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Tele.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Tele.java
@@ -42,7 +42,7 @@ public class Tele extends LinearOpMode {
         );
 
         ButtonAction stopReset = new ButtonAction(
-                new CustomCommand(liftAndScorer::stop),
+                new CustomCommand(liftAndScorer::cancel),
                 commandRunner
         );
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Tele.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/examples/Tele.java
@@ -12,7 +12,9 @@ import org.firstinspires.ftc.teamcode.subsystems.Robot;
 import org.firstinspires.ftc.teamcode.subsystems.Scorer;
 import org.firstinspires.ftc.teamcode.subsystems.TelemetryProfiles;
 import org.ftcvertex.vertices.CommandRunner;
+import org.ftcvertex.vertices.CustomCommand;
 import org.ftcvertex.vertices.SeriesCommand;
+import org.ftcvertex.vertices.StoppableCommand;
 
 @TeleOp(name = "Tele")
 public class Tele extends LinearOpMode {
@@ -27,11 +29,20 @@ public class Tele extends LinearOpMode {
 
         CommandRunner commandRunner = new CommandRunner(telemetryCommand);
 
-        ButtonAction reset = new ButtonAction(
+        StoppableCommand liftAndScorer = new StoppableCommand(
                 new SeriesCommand(
                         new MoveLift(Lift.Targets.GROUND),
                         new MoveScorer(Scorer.Targets.TRANSFER)
-                ),
+                )
+        );
+
+        ButtonAction reset = new ButtonAction(
+                liftAndScorer,
+                commandRunner
+        );
+
+        ButtonAction stopReset = new ButtonAction(
+                new CustomCommand(liftAndScorer::stop),
                 commandRunner
         );
 
@@ -59,6 +70,7 @@ public class Tele extends LinearOpMode {
             reset.update(robot.gamepad1.a);
             transfer.update(robot.gamepad1.b);
             score.update(robot.gamepad1.dpad_down);
+            stopReset.update(robot.gamepad1.dpad_up);
 
             if (robot.gamepad2.right_bumper) {
                 telemetryCommand.setDisabled(true);

--- a/Vertices/src/main/java/org/ftcvertex/vertices/StoppableCommand.java
+++ b/Vertices/src/main/java/org/ftcvertex/vertices/StoppableCommand.java
@@ -1,43 +1,63 @@
 package org.ftcvertex.vertices;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class StoppableCommand implements Command{
-    private final Command command;
-    private boolean commandStopped = false;
+    private final List<Command> commands = new ArrayList<>();
+    private boolean commandCanceled = false;
     private boolean disabled = false;
 
-    public StoppableCommand(Command command){
-        this.command = command;
+    public StoppableCommand(Command... commands){
+        this.commands.addAll(Arrays.asList(commands));
     }
 
     @Override
     public void init() {
-        command.init();
+        for(Command command : commands){
+            command.init();
+        }
     }
 
     @Override
     public void loop() {
+        List<Command> toRemove = new ArrayList<>();
         if(!disabled) {
-            command.loop();
+            for(Command command : commands) {
+                command.loop();
+
+                if(command.isFinished()){
+                    toRemove.add(command);
+                }
+            }
+            commands.removeAll(toRemove);
         }
     }
 
-    public void stop(){
-        commandStopped = true;
+    ///Permanently halts all commands and marks as finished.
+    public void cancel(){
+        commands.clear();
+        commandCanceled = true;
     }
 
+    ///Temporarily halt the commands from running
     public void disable(){
-        disabled = true;
-    }
-    public void enable(){
-        disabled = false;
+        disabled = !commandCanceled;
     }
 
+    ///Resume the commands
+    public void enable(){
+        disabled = commandCanceled;
+    }
+
+    ///@return The disabled state of the command
     public boolean isDisabled(){
         return disabled;
     }
 
     @Override
     public boolean isFinished() {
-        return command.isFinished() || commandStopped;
+        return commands.isEmpty() || commandCanceled;
     }
 }

--- a/Vertices/src/main/java/org/ftcvertex/vertices/StoppableCommand.java
+++ b/Vertices/src/main/java/org/ftcvertex/vertices/StoppableCommand.java
@@ -1,0 +1,43 @@
+package org.ftcvertex.vertices;
+
+public class StoppableCommand implements Command{
+    private final Command command;
+    private boolean commandStopped = false;
+    private boolean disabled = false;
+
+    public StoppableCommand(Command command){
+        this.command = command;
+    }
+
+    @Override
+    public void init() {
+        command.init();
+    }
+
+    @Override
+    public void loop() {
+        if(!disabled) {
+            command.loop();
+        }
+    }
+
+    public void stop(){
+        commandStopped = true;
+    }
+
+    public void disable(){
+        disabled = true;
+    }
+    public void enable(){
+        disabled = false;
+    }
+
+    public boolean isDisabled(){
+        return disabled;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return command.isFinished() || commandStopped;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This pull request includes the following changes from the last 3 commits(Most recent commit last):

- **Added a StoppableCommand wrapper**  
   - [Commit de49f5ce](https://github.com/jkelley129/Vertices/commit/de49f5ce6b203711d9472be09d826af0041a9bf4)  
   - Introduced a new wrapper called `StoppableCommand`, which enables commands to be stopped or interrupted as needed. This adds greater control over command execution and enhances the framework's extensibility.
  
   
- **Update README.md with comprehensive documentation**  
   - [Commit 6d7bc14f](https://github.com/jkelley129/Vertices/commit/6d7bc14f75539795221b83888022a9939db8aeb7)  
   - Expanded the `README.md` to provide in-depth and comprehensive documentation. Includes a quick-reference for the command architecture and detailed explanations of built-in commands in the Vertices framework.
- **Made StoppableCommand accept varargs**  
   - [Commit c2f363f8](https://github.com/jkelley129/Vertices/commit/c2f363f8b5e1fb262787fb66fd63cffd86f26500)  
   - Enhanced the `StoppableCommand` so it can accept a variable number of arguments (varargs). This improves flexibility for command input handling and makes it easier to pass parameters to commands that may have different argument requirements. This commit also strengthened the structure of the command and made sure method naming was clear

---

### Summary
- Improved command handling with a varargs-capable `StoppableCommand`.
- Updated documentation for better developer onboarding and reference.
- Added a robust command wrapper to support stoppable commands.